### PR TITLE
Updated readme version pill and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
    <a href="https://play.google.com/store/apps/details?id=dev.hemanths.paisa" style="text-decoration:none" area-label="flutter">
     <img src="https://img.shields.io/badge/Download-Google%20Play-green">
   </a>
-  <a href="https://github.com/h4h13/paisa" style="text-decoration:none" area-label="flutter">
-    <img src="https://img.shields.io/badge/Version-1.6.0-orange">
+  <a href="https://github.com/RetroMusicPlayer/Paisa/releases/tag/v2.0.2" style="text-decoration:none" area-label="flutter">
+    <img src="https://img.shields.io/badge/Version-2.0.2-orange">
   </a>
 </p>
 <p  align="center">


### PR DESCRIPTION
In the readme the version was outdated and it redirected to the repository, now it redirects to the version tag