### PR TITLE
Add currency Dominican Peso

### DIFF
--- a/lib/src/data/currencies/repository/currencies_repository_impl.dart
+++ b/lib/src/data/currencies/repository/currencies_repository_impl.dart
@@ -46,4 +46,5 @@ List<Currency> _getLocales() => [
       Currency("Hungarian Forint", const Locale('hu')),
       Currency("Romanian Leu", const Locale('ro')),
       Currency("Macedonian Denar", const Locale('mk')),
+      Currency("Dominican Peso", const Locale('es-do')),
     ];


### PR DESCRIPTION
Add currency for the Dominican Republic.

I don't know where you get the symbol for each currency, for the Dominican Republic it is (RD$) but it appears as European currency (€) in the APP.

I would like to know what you use to identify the symbol for each currency for each country.

![Screenshot_1678763679](https://user-images.githubusercontent.com/36754778/224884102-7098e2b1-77c2-46a6-92b1-b5ceac1238b7.png)
