### PR TITLE
Fix padding on Settings page on devices with bottom notch

### DIFF
--- a/lib/src/presentation/settings/pages/setting_page.dart
+++ b/lib/src/presentation/settings/pages/setting_page.dart
@@ -124,9 +124,12 @@ class SettingsPage extends StatelessWidget {
                     const VersionWidget(),
                   ],
                 ),
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Text(context.loc.madeWithLoveInIndiaLabel),
+                SafeArea(
+                  top: false,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(context.loc.madeWithLoveInIndiaLabel),
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
On devices with bottom screen cut outs the "Made with love in India" text was hidden behind the cut out.