### PR TITLE
Disable contrast enforce for navigation bar

### DIFF
--- a/lib/src/presentation/widgets/paisa_annotate_region_widget.dart
+++ b/lib/src/presentation/widgets/paisa_annotate_region_widget.dart
@@ -19,7 +19,7 @@ class PaisaAnnotatedRegionWidget extends StatelessWidget {
             Theme.of(context).brightness == Brightness.dark
                 ? Brightness.light
                 : Brightness.dark,
-        systemNavigationBarContrastEnforced: true,
+        systemNavigationBarContrastEnforced: false,
       ),
       child: child,
     );


### PR DESCRIPTION
Issue #79

Hi,

I'm new to flutter and this project. Below is my current understanding as per which have done the fix:

`systemNavigationBarContrastEnforced` [link](https://api.flutter.dev/flutter/services/SystemUiOverlayStyle/systemNavigationBarContrastEnforced.html) --> This will update the `systemNavigationBarColor` to ensure contrast.

Hence, setting it to false to avoid the override of navigation bar color. Not sure if my understanding is complete but in my local testing it looks okay in dark and light theme (screenshots attached)

I'm using Pixel 2 API 32 emulator with GMS for the test.

![dark_theme_navbar](https://github.com/RetroMusicPlayer/Paisa/assets/17106096/556e6624-2734-460c-8251-9305e89f5bbe)
![light_theme_navbar](https://github.com/RetroMusicPlayer/Paisa/assets/17106096/ecfa2f8b-0e02-4b94-af2c-9f55adb2c068)


Personally, I feel in dark mode, icons are dimmer but haven't checked in actual phone so can't comment yet. Wanted to raise PR to get other's opinions as well.

Note:
In my local build I was getting error
lib/src/presentation/expense/pages/expense_page.dart:330:26: Error: Cannot invoke a non-'const' constructor where a const expression is expected.
Hence I had removed "const" keyword from line-329 after which I was able to build. Not sure if my setup issue or I'm doing something differently.
However, for this issue I don't this it should have any bearing as that issue was coming without any of my change as well.