### PR TITLE
sort transactions to get latest on top

### DIFF
--- a/lib/features/home/presentation/pages/summary/summary_page.dart
+++ b/lib/features/home/presentation/pages/summary/summary_page.dart
@@ -18,7 +18,7 @@ class SummaryPage extends StatelessWidget {
     return ValueListenableBuilder<Box<TransactionModel>>(
       valueListenable: getIt.get<Box<TransactionModel>>().listenable(),
       builder: (_, value, child) {
-        final expenses = value.values.toEntities();
+        final expenses = value.values.toEntities().reversed.toList();
         return ScreenTypeLayout(
           mobile: SummaryMobileWidget(expenses: expenses),
           tablet: SummaryTabletWidget(expenses: expenses),


### PR DESCRIPTION
Restored the original order in which transactions list appeared in the summary page of the home screen. Now the latest transactions appear on top