### PR TITLE
Fix month not showing for old transaction

### DIFF
--- a/lib/core/extensions/time_extension.dart
+++ b/lib/core/extensions/time_extension.dart
@@ -88,6 +88,23 @@ extension DateUtils on DateTime {
     return (isAfter(range.start) || isAtSameMomentAs(range.start)) &&
         (isAtSameMomentAs(range.end) || isBefore(range.end));
   }
+
+  String get dateString {
+    DateTime now = DateTime.now();
+
+    if (year == now.year) {
+      if (month == now.month) {
+        DateFormat format = DateFormat('dd EEE • hh:mm a');
+        return format.format(this);
+      } else {
+        DateFormat format = DateFormat('dd MMM • EEE • hh:mm a');
+        return format.format(this);
+      }
+    } else {
+      DateFormat format = DateFormat('dd MMM yyyy • hh:mm a');
+      return format.format(this);
+    }
+  }
 }
 
 int daysElapsedSince(DateTime from, DateTime to) {

--- a/lib/features/home/presentation/pages/summary/widgets/expense_item_widget.dart
+++ b/lib/features/home/presentation/pages/summary/widgets/expense_item_widget.dart
@@ -21,11 +21,11 @@ class ExpenseItemWidget extends StatelessWidget {
 
   String getSubtitle(BuildContext context) {
     if (expense.type == TransactionType.transfer) {
-      return expense.time!.shortDayString;
+      return expense.time!.dateString;
     } else {
       return context.loc.transactionSubTittleText(
         account.bankName ?? '',
-        expense.time!.shortDayString,
+        expense.time!.dateString,
       );
     }
   }
@@ -103,7 +103,7 @@ class ExpenseTransferItemWidget extends StatelessWidget {
         ),
         child: ListTile(
           title: Text(title),
-          subtitle: Text(expense.time!.shortDayString),
+          subtitle: Text(expense.time!.dateString),
           leading: CircleAvatar(
             backgroundColor: context.primary.withOpacity(0.2),
             child: Icon(


### PR DESCRIPTION
Fix transaction by category screen in the overview page not showing month and year for old transactions. 

**Screenshots:**

*Before*
<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/65854965/271898472-cd5ba47f-a144-4d47-8a7f-40a66f352ee7.png" alt="Old Transaction View" height="500">

*After*
<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/65854965/271898553-79f05a42-7297-4418-9c35-877bb1c3f1b6.png" alt="Old Transaction View" height="500">

