### PR TITLE
Fix overview page shows all expense for category

### DIFF
--- a/lib/core/extensions/expense_extensions.dart
+++ b/lib/core/extensions/expense_extensions.dart
@@ -92,6 +92,9 @@ extension ExpensesHelper on Iterable<TransactionEntity> {
   List<TransactionEntity> isFilterTimeBetween(DateTimeRange range) =>
       where((element) => element.time!.isAfterBeforeTime(range)).toList();
 
+  List<TransactionEntity> transactionsForCid(int cid) =>
+      where((element) => element.categoryId! == cid).toList();
+
   double get filterTotal => fold<double>(0, (previousValue, element) {
         if (element.type == TransactionType.expense) {
           return previousValue - (element.currency ?? 0);

--- a/lib/features/home/presentation/cubit/overview/overview_cubit.dart
+++ b/lib/features/home/presentation/cubit/overview/overview_cubit.dart
@@ -71,6 +71,13 @@ class OverviewCubit extends Cubit<BudgetState> {
   void fetchDefaultCategory() {
     _defaultCategories.addAll(getCategoriesUseCase(NoParams()));
   }
+
+  List<TransactionEntity> expensesForCid(int cid) {
+    final List<TransactionEntity> selectedTimeExpenses =
+        _groupedExpenses[selectedTime] ?? [];
+
+    return selectedTimeExpenses.transactionsForCid(cid);
+  }
 }
 
 abstract class BudgetState extends Equatable {

--- a/lib/features/home/presentation/pages/overview/transactions_by_category_list_page.dart
+++ b/lib/features/home/presentation/pages/overview/transactions_by_category_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -10,6 +11,8 @@ import 'package:paisa/features/transaction/domain/entities/transaction.dart';
 import 'package:paisa/features/home/presentation/controller/summary_controller.dart';
 
 import 'package:paisa/core/widgets/paisa_widget.dart';
+
+import '../../cubit/overview/overview_cubit.dart';
 
 class TransactionByCategoryListPage extends StatelessWidget {
   const TransactionByCategoryListPage({
@@ -25,7 +28,7 @@ class TransactionByCategoryListPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final int cid = int.parse(categoryId);
     final List<TransactionEntity> expenses =
-        BlocProvider.of<HomeBloc>(context).fetchExpensesFromCategoryId(cid);
+        BlocProvider.of<OverviewCubit>(context).expensesForCid(cid);
 
     return PaisaAnnotatedRegionWidget(
       color: Colors.transparent,


### PR DESCRIPTION
When selecting any category from the overview page after setting up any time filter, it shows all-time expenses for that category, it should show expenses for that time range only.

*Before*

https://github.com/RetroMusicPlayer/Paisa/assets/65854965/57e12c9b-ac73-471d-aab4-d8ecf126eac8

*After*

https://github.com/RetroMusicPlayer/Paisa/assets/65854965/cb18a193-61f5-4ac3-9d89-080fe7a113bd
