### PR TITLE
fix: primary color selection error on web

### DIFF
--- a/lib/features/settings/presentation/widgets/settings_color_picker_widget.dart
+++ b/lib/features/settings/presentation/widgets/settings_color_picker_widget.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:hive_flutter/adapters.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -74,7 +75,7 @@ class ColorPickerDialogWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (Platform.isAndroid) {
+    if (!kIsWeb && Platform.isAndroid) {
       return FutureResolve<AndroidDeviceInfo>(
         future: DeviceInfoPlugin().androidInfo,
         builder: (info) {


### PR DESCRIPTION
When opening the color picker dialog on web an early return is added when checking the platform
Flutter throws an exception if you try to access the platform when running from the browser