### PR TITLE
Don't take transfers into account when calculating income/expense

### DIFF
--- a/lib/core/extensions/expense_extensions.dart
+++ b/lib/core/extensions/expense_extensions.dart
@@ -91,6 +91,9 @@ extension ExpensesHelper on Iterable<TransactionEntity> {
   List<TransactionEntity> get incomeList =>
       where((element) => element.type == TransactionType.income).toList();
 
+  List<TransactionEntity> get transferList =>
+      where((element) => element.type == TransactionType.transfer).toList();
+
   List<TransactionEntity> isFilterTimeBetween(DateTimeRange range) =>
       where((element) => element.time!.isAfterBeforeTime(range)).toList();
 
@@ -106,12 +109,15 @@ extension ExpensesHelper on Iterable<TransactionEntity> {
           return previousValue;
         }
       });
-  double get fullTotal => totalIncome - totalExpense;
+  double get fullTotal => totalIncome - totalExpense + totalTransfer;
 
   double get totalExpense => expenseList.map((e) => e.currency).fold<double>(
       0, (previousValue, element) => previousValue + (element ?? 0));
 
   double get totalIncome => incomeList.map((e) => e.currency).fold<double>(
+      0, (previousValue, element) => previousValue + (element ?? 0));
+
+  double get totalTransfer => transferList.map((e) => e.currency).fold<double>(
       0, (previousValue, element) => previousValue + (element ?? 0));
 
   double get total => map((e) => e.currency).fold<double>(

--- a/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -127,11 +127,11 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       await addTransactionUseCase(AddTransactionParams(
         name:
             'Transfer from ${fromAccount!.bankName} to ${toAccount!.bankName}',
-        amount: validAmount,
+        amount: -validAmount,
         time: selectedDate,
         categoryId: categoryId,
         accountId: fromAccount!.superId!,
-        transactionType: TransactionType.expense,
+        transactionType: TransactionType.transfer,
         description: '',
       ));
 
@@ -142,7 +142,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         time: selectedDate,
         categoryId: categoryId,
         accountId: toAccount!.superId!,
-        transactionType: TransactionType.income,
+        transactionType: TransactionType.transfer,
         description: '',
       ));
 


### PR DESCRIPTION
This does not apply to transfers made before these changes.

# Demo
<img src="https://github.com/RetroMusicPlayer/Paisa/assets/5513919/ec68a7c5-3b58-4d2c-afff-50dfbed693b3" height="400">
<img src="https://github.com/RetroMusicPlayer/Paisa/assets/5513919/eb7d43bd-54a1-4fd6-9fd6-8616ff1ca41b" height="400">

# After registering income
<img src="https://github.com/RetroMusicPlayer/Paisa/assets/5513919/c95ca2d2-e925-4ff3-94ce-c6e41400ec38" height="400">

closes #324
