### PR TITLE
Refactored `l10n.yaml` to allow the generation of a file containing untranslated elements.

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,3 +1,5 @@
 arb-dir: lib/localization
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+nullable-getter: false
+untranslated-messages-file: l10n_untranslated.txt


### PR DESCRIPTION
I edited the `l10n.yaml` file so that I can run the "flutter gen-l10n" command to generate a file called `l10n_untranslated.txt` that contains the untranslated elements. 
This way we can know what the elements that we should translate instead of searching for them manually.